### PR TITLE
IDA 6.6 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CC=g++
 LD=g++
 # binary is always i386
 CFLAGS=-arch i386 -D__IDP__ -D__PLUGIN__ -c -D__MAC__ $(SWITCH64) -I$(SDKPATH)/include $(SRC)
-LDFLAGS=-arch i386 --shared $(OBJS) -L$(SDKPATH) -L$(SDKPATH)/bin -l$(LIBTARGET) --no-undefined -Wl -L$(LIBRARYPATH)
+LDFLAGS=-arch i386 --shared $(OBJS) -L$(SDKPATH) -L$(SDKPATH)/bin -l$(LIBTARGET) -Wl -L$(LIBRARYPATH)
 
 all:
 	$(CC) $(CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,24 @@
-EXTENSION=pmc
-LIBTARGET=ida
-# 64bits settings
-ifdef __EA64__
-SWITCH64=-D__EA64__
-EXTENSION=pmc64
-LIBTARGET=ida64
-endif
+PROC=extractmacho
+O1=validate
+O2=extractors
 
-SDKPATH=CHANGME_AND_POINT_TO_THE_SDK_DIR
-LIBRARYPATH=CHANGEME_AND_POINT_TO_THE_IDAQ.APP_MACOS_FOLDER
-#SDKPATH=/Applications/IDA\ Pro\ 6.3/idasdk63
-#LIBRARYPATH=/Applications/IDA\ Pro\ 6.3/idaq.app/Contents/MacOS/
-SRC=extractmacho.cpp validate.cpp extractors.cpp
-OBJS=extractmacho.o validate.o extractors.o
-CC=g++
-LD=g++
-# binary is always i386
-CFLAGS=-arch i386 -D__IDP__ -D__PLUGIN__ -c -D__MAC__ $(SWITCH64) -I$(SDKPATH)/include $(SRC)
-LDFLAGS=-arch i386 --shared $(OBJS) -L$(SDKPATH) -L$(SDKPATH)/bin -l$(LIBTARGET) -Wl -L$(LIBRARYPATH)
+include ../plugin.mak
 
-all:
-	$(CC) $(CFLAGS)
-	$(LD) $(LDFLAGS) -o extractmacho.$(EXTENSION)
+# MAKEDEP dependency list ------------------
+$(F)extractmacho$(O)   : $(I)bitrange.hpp $(I)bytes.hpp $(I)fpro.h   \
+	          $(I)funcs.hpp $(I)ida.hpp $(I)idp.hpp $(I)kernwin.hpp     \
+	          $(I)lines.hpp $(I)llong.hpp $(I)loader.hpp $(I)nalt.hpp   \
+	          $(I)netnode.hpp $(I)pro.h $(I)segment.hpp   \
+	          $(I)ua.hpp $(I)xref.hpp extractmacho.cpp
 
+$(F)validate$(O)   : $(I)bitrange.hpp $(I)bytes.hpp $(I)fpro.h  \
+	          $(I)funcs.hpp $(I)ida.hpp $(I)idp.hpp $(I)kernwin.hpp     \
+	          $(I)lines.hpp $(I)llong.hpp $(I)loader.hpp $(I)nalt.hpp   \
+	          $(I)netnode.hpp $(I)pro.h $(I)segment.hpp   \
+	          $(I)ua.hpp $(I)xref.hpp validate.cpp
+
+$(F)extractors$(O)   : $(I)bitrange.hpp $(I)bytes.hpp $(I)fpro.h  \
+	          $(I)funcs.hpp $(I)ida.hpp $(I)idp.hpp $(I)kernwin.hpp     \
+	          $(I)lines.hpp $(I)llong.hpp $(I)loader.hpp $(I)nalt.hpp   \
+	          $(I)netnode.hpp $(I)pro.h $(I)segment.hpp   \
+	          $(I)ua.hpp $(I)xref.hpp extractors.cpp

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -183,7 +183,7 @@ void IDAP_run(int arg)
             {
                 findAddress = bin_search(findAddress, inf.maxEA, archmagic[i], NULL, 4, BIN_SEARCH_FORWARD, BIN_SEARCH_NOCASE);
                 struct found_fat *f = NULL;
-                HASH_FIND(hh, found_fat, &findAddress, sizeof(ea_t), f);
+                HASH_FIND(hh, found_fat, &findAddress, 4, f);
                 if (findAddress != BADADDR && f == NULL)
                 {
                     char output[MAXSTR];

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -142,7 +142,7 @@ void IDAP_run(int arg)
             return;
         
         // we want to avoid dumping itself so we start at one byte ahead of the first address in the database
-        int findAddress = inf.minEA+1;
+        ea_t findAddress = inf.minEA+1;
         uchar magicFat[]    = "\xCA\xFE\xBA\xBE";
         
         // we have a small problem here
@@ -158,7 +158,11 @@ void IDAP_run(int arg)
             {
                 add_to_fat_list(findAddress);
                 char output[MAXSTR];
+#ifdef __EA64__
+                qsnprintf(output, sizeof(output)-1, "%s/extracted_offset_0x%llx_fat", outputDir, findAddress);
+#else
                 qsnprintf(output, sizeof(output)-1, "%s/extracted_offset_0x%x_fat", outputDir, findAddress);
+#endif
                 extract_binary(findAddress, output);
                 findAddress += 1;
             }
@@ -183,7 +187,11 @@ void IDAP_run(int arg)
                 if (findAddress != BADADDR && f == NULL)
                 {
                     char output[MAXSTR];
+#ifdef __EA64__
+                    qsnprintf(output, sizeof(output)-1, "%s/extracted_offset_0x%llx", outputDir, findAddress);
+#else
                     qsnprintf(output, sizeof(output)-1, "%s/extracted_offset_0x%x", outputDir, findAddress);
+#endif
                     extract_binary(findAddress, output);
                     findAddress += 1;
                 }

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -219,7 +219,11 @@ extract_binary(ea_t address, char *outputFilename)
         {
             if(validate_macho(address))
             {
+#ifdef __EA64__
+                msg("[ERROR] Not a valid mach-o binary at %llx\n", address);
+#else
                 msg("[ERROR] Not a valid mach-o binary at %x\n", address);
+#endif
                 add_to_hits_list(address, (magicValue == MH_MAGIC || magicValue == MH_CIGAM) ? TARGET_32 : TARGET_64, 1);
                 return 1;
             }
@@ -269,9 +273,15 @@ do_report(void)
     struct report *tempReport;
     for (tempReport = report; tempReport != NULL; tempReport = (struct report*)tempReport->hh.next)
     {
+#ifdef __EA64__
+        msg("Address: 0x%016llx Type: %6s Extracted: %s\n", tempReport->id, 
+            tempReport->type == 0 ? "32bits" : tempReport->type == 1 ? "64bits" : "Fat",
+            tempReport->extracted ? "No" : "Yes");
+#else
         msg("Address: 0x%016x Type: %6s Extracted: %s\n", tempReport->id, 
             tempReport->type == 0 ? "32bits" : tempReport->type == 1 ? "64bits" : "Fat",
             tempReport->extracted ? "No" : "Yes");
+#endif
     }    
     msg("Mach-O extraction is over!\n");
 }

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -135,7 +135,7 @@ void IDAP_run(int arg)
 
     if (globalSearch)
     {
-        char form[]="Choose output directory\n<~O~utput directory:F:1:64::>";
+        char form[]="Choose output directory\n<~O~utput directory:F:0:64::>";
         char outputDir[MAXSTR] = "";
         // cancelled
         if (AskUsingForm_c(form, outputDir) == 0)

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -40,7 +40,7 @@
 #include "validate.h"
 #include "uthash.h"
 
-#define VERSION "1.1"
+#define VERSION "1.1.1"
 //#define DEBUG 0
 
 uint8_t extract_binary(ea_t address, char *outputFilename);


### PR DESCRIPTION
Hello

As you kindly suggested, I fixed ExtractMachO for IDA 6.6

Aside from the dialog (8fd89a8), there was an issue with findAddress type (ea_t would not fit nicely in a int on 64-bit - 1793ddd) so the while would never equals to BADADDR: infinite loop.

Side effect was broken HASH_FIND (FAT filter), so I hardcoded HASH_FIND keylen (0ca7e3f).

Cheers.

Arnaud
