### PR TITLE
IDA 7.0 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,24 @@
-TARGET=extractmacho.dylib
-LIBTARGET=ida
-# 64bits settings
-ifdef __EA64__
-SWITCH64=-D__EA64__
-TARGET=extractmacho64.dylib
-LIBTARGET=ida64
-endif
+PROC=extractmacho
+O1=validate
+O2=extractors
 
-SDKPATH=CHANGME_AND_POINT_TO_THE_SDK_DIR
-LIBRARYPATH=CHANGEME_AND_POINT_TO_THE_IDAQ.APP_MACOS_FOLDER
-#SDKPATH=/Applications/IDA\ Pro\ 7.0/idasdk70
-#LIBRARYPATH=/Applications/IDA\ Pro\ 7.0/ida.app/Contents/MacOS/
-SRC=extractmacho.cpp validate.cpp extractors.cpp
-OBJS=extractmacho.o validate.o extractors.o
-CC=g++
-LD=g++
-CFLAGS=-D__IDP__ -D__PLUGIN__ -c -D__MAC__ $(SWITCH64) -I$(SDKPATH)/include $(SRC)
-LDFLAGS=--shared $(OBJS) -L$(SDKPATH) -L$(SDKPATH)/bin -l$(LIBTARGET) -Wl -L$(LIBRARYPATH)
+include ../plugin.mak
 
-all:
-	$(CC) $(CFLAGS)
+# MAKEDEP dependency list ------------------
+$(F)extractmacho$(O)   : $(I)bitrange.hpp $(I)bytes.hpp $(I)config.hpp $(I)fpro.h  \
+	          $(I)funcs.hpp $(I)ida.hpp $(I)idp.hpp $(I)kernwin.hpp     \
+	          $(I)lines.hpp $(I)llong.hpp $(I)loader.hpp $(I)nalt.hpp   \
+	          $(I)netnode.hpp $(I)pro.h $(I)range.hpp $(I)segment.hpp   \
+	          $(I)ua.hpp $(I)xref.hpp extractmacho.cpp
 
-	$(LD) $(LDFLAGS) -o $(TARGET)
+$(F)validate$(O)   : $(I)bitrange.hpp $(I)bytes.hpp $(I)config.hpp $(I)fpro.h  \
+	          $(I)funcs.hpp $(I)ida.hpp $(I)idp.hpp $(I)kernwin.hpp     \
+	          $(I)lines.hpp $(I)llong.hpp $(I)loader.hpp $(I)nalt.hpp   \
+	          $(I)netnode.hpp $(I)pro.h $(I)range.hpp $(I)segment.hpp   \
+	          $(I)ua.hpp $(I)xref.hpp validate.cpp
+
+$(F)extractors$(O)   : $(I)bitrange.hpp $(I)bytes.hpp $(I)config.hpp $(I)fpro.h  \
+	          $(I)funcs.hpp $(I)ida.hpp $(I)idp.hpp $(I)kernwin.hpp     \
+	          $(I)lines.hpp $(I)llong.hpp $(I)loader.hpp $(I)nalt.hpp   \
+	          $(I)netnode.hpp $(I)pro.h $(I)range.hpp $(I)segment.hpp   \
+	          $(I)ua.hpp $(I)xref.hpp extractors.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,24 @@
-EXTENSION=pmc
+TARGET=extractmacho.dylib
 LIBTARGET=ida
 # 64bits settings
 ifdef __EA64__
 SWITCH64=-D__EA64__
-EXTENSION=pmc64
+TARGET=extractmacho64.dylib
 LIBTARGET=ida64
 endif
 
 SDKPATH=CHANGME_AND_POINT_TO_THE_SDK_DIR
 LIBRARYPATH=CHANGEME_AND_POINT_TO_THE_IDAQ.APP_MACOS_FOLDER
-#SDKPATH=/Applications/IDA\ Pro\ 6.3/idasdk63
-#LIBRARYPATH=/Applications/IDA\ Pro\ 6.3/idaq.app/Contents/MacOS/
+#SDKPATH=/Applications/IDA\ Pro\ 7.0/idasdk70
+#LIBRARYPATH=/Applications/IDA\ Pro\ 7.0/ida.app/Contents/MacOS/
 SRC=extractmacho.cpp validate.cpp extractors.cpp
 OBJS=extractmacho.o validate.o extractors.o
 CC=g++
 LD=g++
-# binary is always i386
-CFLAGS=-arch i386 -D__IDP__ -D__PLUGIN__ -c -D__MAC__ $(SWITCH64) -I$(SDKPATH)/include $(SRC)
-LDFLAGS=-arch i386 --shared $(OBJS) -L$(SDKPATH) -L$(SDKPATH)/bin -l$(LIBTARGET) -Wl -L$(LIBRARYPATH)
+CFLAGS=-D__IDP__ -D__PLUGIN__ -c -D__MAC__ $(SWITCH64) -I$(SDKPATH)/include $(SRC)
+LDFLAGS=--shared $(OBJS) -L$(SDKPATH) -L$(SDKPATH)/bin -l$(LIBTARGET) -Wl -L$(LIBRARYPATH)
 
 all:
 	$(CC) $(CFLAGS)
-	$(LD) $(LDFLAGS) -o extractmacho.$(EXTENSION)
 
+	$(LD) $(LDFLAGS) -o $(TARGET)

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -114,12 +114,12 @@ bool IDAP_run(size_t)
 
     if (magicValue == MH_MAGIC || magicValue == MH_MAGIC_64 || magicValue == FAT_CIGAM)
     {
-        int answer = askyn_c(0, "Current location contains a potential Mach-O binary! Attempt to extract only this one?");
+        int answer = ask_yn(0, "Current location contains a potential Mach-O binary! Attempt to extract only this one?");
         // user wants to extract this binary
         if (answer == 1)
         {
             // ask for output location & name
-            outputFilename = askfile_c(1, NULL, "Select output file...");
+            outputFilename = ask_file(1, NULL, "Select output file...");
             if (outputFilename == NULL || outputFilename[0] == 0)
                 return false;
             extract_binary(cursorAddress, outputFilename);
@@ -138,7 +138,7 @@ bool IDAP_run(size_t)
         char form[]="Choose output directory\n<~O~utput directory:F:0:64::>";
         char outputDir[MAXSTR] = "";
         // cancelled
-        if (AskUsingForm_c(form, outputDir) == 0)
+        if (ask_form(form, outputDir) == 0)
             return false;
         
         // we want to avoid dumping itself so we start at one byte ahead of the first address in the database

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -40,7 +40,7 @@
 #include "validate.h"
 #include "uthash.h"
 
-#define VERSION "1.1.1"
+#define VERSION "1.1.2"
 //#define DEBUG 0
 
 uint8_t extract_binary(ea_t address, char *outputFilename);

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -237,7 +237,7 @@ extract_binary(ea_t address, char *outputFilename)
             }
             // we just need to read mach_header.filetype so no problem in using the 32bit struct
             struct mach_header header;
-            get_many_bytes(address, &header, sizeof(struct mach_header));
+            get_bytes(address, &header, sizeof(struct mach_header));
             uint32_t filetype = (magicValue == MH_MAGIC || magicValue == MH_MAGIC_64) ? header.filetype : ntohl(header.filetype);
             if (filetype == MH_OBJECT)
                 retValue = extract_mhobject(address, outputFilename);
@@ -316,7 +316,7 @@ add_to_fat_list(ea_t address)
 {
     // process the fat structures
     struct fat_header fatHeader;
-    get_many_bytes(address, &fatHeader, sizeof(struct fat_header));
+    get_bytes(address, &fatHeader, sizeof(struct fat_header));
     if (fatHeader.magic == FAT_CIGAM)
     {
         // fat headers are always big endian!
@@ -328,7 +328,7 @@ add_to_fat_list(ea_t address)
             for (uint32_t i = 0; i < nfat_arch; i++)
             {
                 struct fat_arch fatArch;
-                get_many_bytes(archAddress, &fatArch, sizeof(struct fat_arch));
+                get_bytes(archAddress, &fatArch, sizeof(struct fat_arch));
                 // binary is located at start of fat magic plus offset found in the fat_arch structure
                 ea_t binLocation = address + ntohl(fatArch.offset);
                 

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -40,7 +40,7 @@
 #include "validate.h"
 #include "uthash.h"
 
-#define VERSION "1.1.2"
+#define VERSION "1.1.3"
 //#define DEBUG 0
 
 uint8_t extract_binary(ea_t address, char *outputFilename);

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -237,7 +237,7 @@ extract_binary(ea_t address, char *outputFilename)
             }
             // we just need to read mach_header.filetype so no problem in using the 32bit struct
             struct mach_header header;
-            get_bytes(address, &header, sizeof(struct mach_header));
+            get_bytes(&header, sizeof(struct mach_header), address);
             uint32_t filetype = (magicValue == MH_MAGIC || magicValue == MH_MAGIC_64) ? header.filetype : ntohl(header.filetype);
             if (filetype == MH_OBJECT)
                 retValue = extract_mhobject(address, outputFilename);
@@ -316,7 +316,7 @@ add_to_fat_list(ea_t address)
 {
     // process the fat structures
     struct fat_header fatHeader;
-    get_bytes(address, &fatHeader, sizeof(struct fat_header));
+    get_bytes(&fatHeader, sizeof(struct fat_header), address);
     if (fatHeader.magic == FAT_CIGAM)
     {
         // fat headers are always big endian!
@@ -328,7 +328,7 @@ add_to_fat_list(ea_t address)
             for (uint32_t i = 0; i < nfat_arch; i++)
             {
                 struct fat_arch fatArch;
-                get_bytes(archAddress, &fatArch, sizeof(struct fat_arch));
+                get_bytes(&fatArch, sizeof(struct fat_arch), archAddress);
                 // binary is located at start of fat magic plus offset found in the fat_arch structure
                 ea_t binLocation = address + ntohl(fatArch.offset);
                 

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -105,7 +105,7 @@ bool IDAP_run(size_t)
     // retrieve current cursor address and it's value
     // so we can verify if it can be a mach-o binary
     ea_t cursorAddress = get_screen_ea();
-    uint32 magicValue = get_long(cursorAddress);
+    uint32 magicValue = get_dword(cursorAddress);
     
     uint8_t globalSearch = 1;
     char *outputFilename = NULL;
@@ -217,7 +217,7 @@ uint8_t
 extract_binary(ea_t address, char *outputFilename)
 {
     uint8_t retValue = 0;
-    uint32 magicValue = get_long(address);
+    uint32 magicValue = get_dword(address);
     switch (magicValue)
     {
         case MH_MAGIC:

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -40,7 +40,7 @@
 #include "validate.h"
 #include "uthash.h"
 
-#define VERSION "1.1.3"
+#define VERSION "1.1.4"
 //#define DEBUG 0
 
 uint8_t extract_binary(ea_t address, char *outputFilename);

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -92,7 +92,7 @@ void IDAP_term(void)
     return;
 }
 
-void IDAP_run(int arg)
+bool IDAP_run(size_t)
 { 
     // this is useful for testing - plugin will be unloaded after execution
     // so we can copy a new version and call it again using IDC: RunPlugin("extractmacho", -1);
@@ -121,14 +121,14 @@ void IDAP_run(int arg)
             // ask for output location & name
             outputFilename = askfile_c(1, NULL, "Select output file...");
             if (outputFilename == NULL || outputFilename[0] == 0)
-                return;
+                return false;
             extract_binary(cursorAddress, outputFilename);
             do_report();
-            return;
+            return true;
         }
         // cancelled
         if (answer == -1)
-            return;
+            return false;
         
         globalSearch = answer ? 0 : 1;
     }
@@ -139,7 +139,7 @@ void IDAP_run(int arg)
         char outputDir[MAXSTR] = "";
         // cancelled
         if (AskUsingForm_c(form, outputDir) == 0)
-            return;
+            return false;
         
         // we want to avoid dumping itself so we start at one byte ahead of the first address in the database
         ea_t findAddress = inf.minEA+1;
@@ -207,7 +207,7 @@ void IDAP_run(int arg)
     // output a final report of what happened
     do_report();
     // it's over!
-	return;
+	return true;
 }
 
 /*

--- a/extractmacho.cpp
+++ b/extractmacho.cpp
@@ -142,7 +142,7 @@ bool IDAP_run(size_t)
             return false;
         
         // we want to avoid dumping itself so we start at one byte ahead of the first address in the database
-        ea_t findAddress = inf.minEA+1;
+        ea_t findAddress = inf.min_ea+1;
         uchar magicFat[]    = "\xCA\xFE\xBA\xBE";
         
         // we have a small problem here
@@ -153,7 +153,7 @@ bool IDAP_run(size_t)
         // lookup fat archives
         while (findAddress != BADADDR)
         {
-            findAddress = bin_search(findAddress, inf.maxEA, magicFat, NULL, 4, BIN_SEARCH_FORWARD, BIN_SEARCH_NOCASE);
+            findAddress = bin_search(findAddress, inf.max_ea, magicFat, NULL, 4, BIN_SEARCH_FORWARD, BIN_SEARCH_NOCASE);
             if (findAddress != BADADDR)
             {
                 add_to_fat_list(findAddress);
@@ -168,7 +168,7 @@ bool IDAP_run(size_t)
             }
         }
 
-        findAddress = inf.minEA+1;
+        findAddress = inf.min_ea+1;
         
 #define NR_ARCHS 4
         uchar* archmagic[NR_ARCHS];
@@ -181,7 +181,7 @@ bool IDAP_run(size_t)
         {
             while (findAddress != BADADDR)
             {
-                findAddress = bin_search(findAddress, inf.maxEA, archmagic[i], NULL, 4, BIN_SEARCH_FORWARD, BIN_SEARCH_NOCASE);
+                findAddress = bin_search(findAddress, inf.max_ea, archmagic[i], NULL, 4, BIN_SEARCH_FORWARD, BIN_SEARCH_NOCASE);
                 struct found_fat *f = NULL;
                 HASH_FIND(hh, found_fat, &findAddress, 4, f);
                 if (findAddress != BADADDR && f == NULL)
@@ -200,7 +200,7 @@ bool IDAP_run(size_t)
                     findAddress += 1;
             }
             // reset start address
-            findAddress = inf.minEA+1;
+            findAddress = inf.min_ea+1;
         }
     }
 

--- a/extractors.cpp
+++ b/extractors.cpp
@@ -42,7 +42,7 @@
 uint8_t
 extract_mhobject(ea_t address, char *outputFilename)
 {
-    uint32 magicValue = get_long(address);
+    uint32 magicValue = get_dword(address);
     
     struct mach_header *mach_header = NULL;
     struct mach_header_64 *mach_header64 = NULL;
@@ -277,7 +277,7 @@ extract_mhobject(ea_t address, char *outputFilename)
 uint8_t 
 extract_macho(ea_t address, char *outputFilename)
 {
-    uint32 magicValue = get_long(address);
+    uint32 magicValue = get_dword(address);
     
     struct mach_header *mach_header = NULL;
     struct mach_header_64 *mach_header64 = NULL;

--- a/extractors.cpp
+++ b/extractors.cpp
@@ -55,7 +55,7 @@ extract_mhobject(ea_t address, char *outputFilename)
 #endif
         mach_header = (struct mach_header *)qalloc(sizeof(struct mach_header));
         // retrieve mach_header contents
-        if(!get_bytes(address, mach_header, sizeof(struct mach_header)))
+        if(!get_bytes(mach_header, sizeof(struct mach_header), address))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -67,7 +67,7 @@ extract_mhobject(ea_t address, char *outputFilename)
         msg("[DEBUG] Target is 64bits!\n");
 #endif
         mach_header64 = (struct mach_header_64 *)qalloc(sizeof(struct mach_header_64));
-        if(!get_bytes(address, mach_header64, sizeof(struct mach_header_64)))
+        if(!get_bytes(mach_header64, sizeof(struct mach_header_64), address))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -116,7 +116,7 @@ extract_mhobject(ea_t address, char *outputFilename)
     uint8_t *loadcmdsBuffer = NULL;
     loadcmdsBuffer = (uint8_t*)qalloc(sizeofcmds);
     
-    get_bytes(address + headerSize, loadcmdsBuffer, sizeofcmds);
+    get_bytes(loadcmdsBuffer, sizeofcmds, address + headerSize);
     // write all the load commands block to the output file
     // only LC_SEGMENT commands contain further data
     qfwrite(outputFile, loadcmdsBuffer, sizeofcmds);
@@ -129,7 +129,7 @@ extract_mhobject(ea_t address, char *outputFilename)
     // only the segment commands have useful information
     for (uint32_t i = 0; i < ncmds; i++)
     {
-        get_bytes(cmdsBaseAddress, &loadCommand, sizeof(struct load_command));
+        get_bytes(&loadCommand, sizeof(struct load_command), cmdsBaseAddress);
         struct segment_command segmentCommand;
         struct segment_command_64 segmentCommand64;
         // swap the endianness of some fields if it's powerpc target
@@ -142,7 +142,7 @@ extract_mhobject(ea_t address, char *outputFilename)
         // 32bits targets
         if (loadCommand.cmd == LC_SEGMENT)
         {
-            get_bytes(cmdsBaseAddress, &segmentCommand, sizeof(struct segment_command));
+            get_bytes(&segmentCommand, sizeof(struct segment_command), cmdsBaseAddress);
             // swap the endianness of some fields if it's powerpc target
             if (magicValue == MH_CIGAM)
             {
@@ -157,7 +157,7 @@ extract_mhobject(ea_t address, char *outputFilename)
             // FIXME: we need to find the lowest one since the section info can be reordered
             for (uint32_t x = 0; x < segmentCommand.nsects; x++)
             {
-                get_bytes(sectionAddress, &sectionCommand, sizeof(struct section));
+                get_bytes(&sectionCommand, sizeof(struct section), sectionAddress);
                 // swap the endianness of some fields if it's powerpc target
                 if (magicValue == MH_CIGAM)
                 {
@@ -169,7 +169,7 @@ extract_mhobject(ea_t address, char *outputFilename)
                 {
                     uint32_t size = sectionCommand.nreloc*sizeof(struct relocation_info);
                     uint8_t *relocBuf = (uint8_t*)qalloc(size);
-                    get_bytes(address + sectionCommand.reloff, relocBuf, size);
+                    get_bytes(relocBuf, size, address + sectionCommand.reloff);
                     qfseek(outputFile, sectionCommand.reloff, SEEK_SET);
                     qfwrite(outputFile, relocBuf, size);
                     qfree(relocBuf);
@@ -178,7 +178,7 @@ extract_mhobject(ea_t address, char *outputFilename)
             }
             // read and write the data
             uint8_t *buf = (uint8_t*)qalloc(segmentCommand.filesize);
-            get_bytes(address + segmentCommand.fileoff, buf, segmentCommand.filesize);
+            get_bytes(buf, segmentCommand.filesize, address + segmentCommand.fileoff);
             // always set the offset
             qfseek(outputFile, segmentCommand.fileoff, SEEK_SET);
             qfwrite(outputFile, buf, segmentCommand.filesize);
@@ -188,7 +188,7 @@ extract_mhobject(ea_t address, char *outputFilename)
         else if (loadCommand.cmd == LC_SYMTAB)
         {
             struct symtab_command symtabCommand;
-            get_bytes(cmdsBaseAddress, &symtabCommand, sizeof(struct symtab_command));
+            get_bytes(&symtabCommand, sizeof(struct symtab_command), cmdsBaseAddress);
             // swap the endianness of some fields if it's powerpc target
             if (magicValue == MH_CIGAM || magicValue == MH_CIGAM_64)
             {
@@ -201,7 +201,7 @@ extract_mhobject(ea_t address, char *outputFilename)
             if (symtabCommand.symoff > 0)
             {
                 void *buf = qalloc(symtabCommand.nsyms*sizeof(struct nlist));
-                get_bytes(address + symtabCommand.symoff, buf, symtabCommand.nsyms*sizeof(struct nlist));
+                get_bytes(buf, symtabCommand.nsyms*sizeof(struct nlist), address + symtabCommand.symoff);
                 qfseek(outputFile, symtabCommand.symoff, SEEK_SET);
                 qfwrite(outputFile, buf, symtabCommand.nsyms*sizeof(struct nlist));
                 qfree(buf);
@@ -209,7 +209,7 @@ extract_mhobject(ea_t address, char *outputFilename)
             if (symtabCommand.stroff > 0)
             {
                 void *buf = qalloc(symtabCommand.strsize);
-                get_bytes(address + symtabCommand.stroff, buf, symtabCommand.strsize);
+                get_bytes(buf, symtabCommand.strsize, address + symtabCommand.stroff);
                 qfseek(outputFile, symtabCommand.stroff, SEEK_SET);
                 qfwrite(outputFile, buf, symtabCommand.strsize);
                 qfree(buf);
@@ -219,7 +219,7 @@ extract_mhobject(ea_t address, char *outputFilename)
         // FIXME: will this work ? needs to be tested :-)
         else if (loadCommand.cmd == LC_SEGMENT_64)
         {
-            get_bytes(cmdsBaseAddress, &segmentCommand64, sizeof(struct segment_command_64));
+            get_bytes(&segmentCommand64, sizeof(struct segment_command_64), cmdsBaseAddress);
             // swap the endianness of some fields if it's powerpc target
             if (magicValue == MH_CIGAM_64)
             {
@@ -232,7 +232,7 @@ extract_mhobject(ea_t address, char *outputFilename)
             struct section_64 sectionCommand64;
             for (uint32_t x = 0; x < segmentCommand64.nsects; x++)
             {
-                get_bytes(sectionAddress, &sectionCommand64, sizeof(struct section_64));
+                get_bytes(&sectionCommand64, sizeof(struct section_64), sectionAddress);
                 // swap the endianness of some fields if it's powerpc target
                 if (magicValue == MH_CIGAM_64)
                 {
@@ -245,7 +245,7 @@ extract_mhobject(ea_t address, char *outputFilename)
                 {
                     uint32_t size = sectionCommand64.nreloc*sizeof(struct relocation_info);
                     uint8_t *relocBuf = (uint8_t*)qalloc(size);
-                    get_bytes(address + sectionCommand64.reloff, relocBuf, size);
+                    get_bytes(relocBuf, size, address + sectionCommand64.reloff);
                     qfseek(outputFile, sectionCommand64.reloff, SEEK_SET);
                     qfwrite(outputFile, relocBuf, size);
                     qfree(relocBuf);
@@ -254,7 +254,7 @@ extract_mhobject(ea_t address, char *outputFilename)
             }
             // read and write the data
             uint8_t *buf = (uint8_t*)qalloc(segmentCommand64.filesize);
-            get_bytes(address + segmentCommand64.fileoff, buf, segmentCommand64.filesize);
+            get_bytes(buf, segmentCommand64.filesize, address + segmentCommand64.fileoff);
             qfseek(outputFile, segmentCommand64.fileoff, SEEK_SET);
             qfwrite(outputFile, buf, segmentCommand64.filesize);
             qfree(buf);
@@ -290,7 +290,7 @@ extract_macho(ea_t address, char *outputFilename)
 #endif
         mach_header = (struct mach_header *)qalloc(sizeof(struct mach_header));
         // retrieve mach_header contents
-        if(!get_bytes(address, mach_header, sizeof(struct mach_header)))
+        if(!get_bytes(mach_header, sizeof(struct mach_header), address))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -302,7 +302,7 @@ extract_macho(ea_t address, char *outputFilename)
         msg("[DEBUG] Target is 64bits!\n");
 #endif
         mach_header64 = (struct mach_header_64 *)qalloc(sizeof(struct mach_header_64));
-        if(!get_bytes(address, mach_header64, sizeof(struct mach_header_64)))
+        if(!get_bytes(mach_header64, sizeof(struct mach_header_64), address))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -356,7 +356,7 @@ extract_macho(ea_t address, char *outputFilename)
     uint8_t *loadcmdsBuffer = NULL;
     loadcmdsBuffer = (uint8_t*)qalloc(sizeofcmds);
     
-    get_bytes(address + headerSize, loadcmdsBuffer, sizeofcmds);
+    get_bytes(loadcmdsBuffer, sizeofcmds, address + headerSize);
     // write all the load commands block to the output file
     // only LC_SEGMENT commands contain further data
     qfwrite(outputFile, loadcmdsBuffer, sizeofcmds);
@@ -370,7 +370,7 @@ extract_macho(ea_t address, char *outputFilename)
     // only the segment commands have useful information
     for (uint32_t i = 0; i < ncmds; i++)
     {
-        get_bytes(cmdsBaseAddress, &loadCommand, sizeof(struct load_command));
+        get_bytes(&loadCommand, sizeof(struct load_command), cmdsBaseAddress);
         struct segment_command segmentCommand;
         struct segment_command_64 segmentCommand64;
         // swap the endianness of some fields if it's powerpc target
@@ -384,7 +384,7 @@ extract_macho(ea_t address, char *outputFilename)
         // FIXME: do we also need to dump the relocs info here ?
         if (loadCommand.cmd == LC_SEGMENT)
         {
-            get_bytes(cmdsBaseAddress, &segmentCommand, sizeof(struct segment_command));
+            get_bytes(&segmentCommand, sizeof(struct segment_command), cmdsBaseAddress);
             // swap the endianness of some fields if it's powerpc target
             if (magicValue == MH_CIGAM)
             {
@@ -402,7 +402,7 @@ extract_macho(ea_t address, char *outputFilename)
                 // FIXME: we need to find the lowest one since the section info can be reordered
                 for (uint32_t x = 0; x < segmentCommand.nsects; x++)
                 {
-                    get_bytes(sectionAddress, &sectionCommand, sizeof(struct section));
+                    get_bytes(&sectionCommand, sizeof(struct section), sectionAddress);
                     // swap the endianness of some fields if it's powerpc target
                     if (magicValue == MH_CIGAM)
                         sectionCommand.offset = ntohl(sectionCommand.offset);
@@ -422,7 +422,7 @@ extract_macho(ea_t address, char *outputFilename)
             }
             // read and write the data
             uint8_t *buf = (uint8_t*)qalloc(segmentCommand.filesize);
-            get_bytes(address + codeOffset, buf, segmentCommand.filesize);
+            get_bytes(buf, segmentCommand.filesize, address + codeOffset);
             // always set the offset
             qfseek(outputFile, codeOffset, SEEK_SET);
             qfwrite(outputFile, buf, segmentCommand.filesize);
@@ -431,7 +431,7 @@ extract_macho(ea_t address, char *outputFilename)
         // 64bits targets
         else if (loadCommand.cmd == LC_SEGMENT_64)
         {
-            get_bytes(cmdsBaseAddress, &segmentCommand64, sizeof(struct segment_command_64));
+            get_bytes(&segmentCommand64, sizeof(struct segment_command_64), cmdsBaseAddress);
             // swap the endianness of some fields if it's powerpc target
             if (magicValue == MH_CIGAM_64)
             {
@@ -446,7 +446,7 @@ extract_macho(ea_t address, char *outputFilename)
                 struct section_64 sectionCommand64;
                 for (uint32_t x = 0; x < segmentCommand64.nsects; x++)
                 {
-                    get_bytes(sectionAddress, &sectionCommand64, sizeof(struct section_64));
+                    get_bytes(&sectionCommand64, sizeof(struct section_64), sectionAddress);
                     // swap the endianness of some fields if it's powerpc target
                     if (magicValue == MH_CIGAM_64)
                         sectionCommand64.offset = ntohl(sectionCommand64.offset);
@@ -465,7 +465,7 @@ extract_macho(ea_t address, char *outputFilename)
             }
             // read and write the data
             uint8_t *buf = (uint8_t*)qalloc(segmentCommand64.filesize);
-            get_bytes(address + codeOffset, buf, segmentCommand64.filesize);
+            get_bytes(buf, segmentCommand64.filesize, address + codeOffset);
             qfseek(outputFile, codeOffset, SEEK_SET);
             qfwrite(outputFile, buf, segmentCommand64.filesize);
             qfree(buf);
@@ -491,7 +491,7 @@ extract_fat(ea_t address, char *outputFilename)
     msg("[DEBUG] Trying to extract a fat binary target!\n");
 #endif
     struct fat_header fatHeader;
-    if(!get_bytes(address, &fatHeader, sizeof(struct fat_header)))
+    if(!get_bytes(&fatHeader, sizeof(struct fat_header), address))
     {
         msg("[ERROR] Read bytes failed!\n");
         return 1;
@@ -514,7 +514,7 @@ extract_fat(ea_t address, char *outputFilename)
     uint32_t fatArchSize = sizeof(struct fat_arch)*ntohl(fatHeader.nfat_arch);
     // write all fat_arch structs
     void *fatArchBuf = qalloc(fatArchSize);
-    if(!get_bytes(fatArchAddress, fatArchBuf, fatArchSize))
+    if(!get_bytes(fatArchBuf, fatArchSize, fatArchAddress))
     {
         msg("[ERROR] Read bytes failed!\n");
         return 1;
@@ -526,14 +526,14 @@ extract_fat(ea_t address, char *outputFilename)
     {
         struct fat_arch tempFatArch;
         // read the fat_arch struct
-        if(!get_bytes(fatArchAddress, &tempFatArch, sizeof(struct fat_arch)))
+        if(!get_bytes(&tempFatArch, sizeof(struct fat_arch), fatArchAddress))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
         }
         // read and write the mach-o binary pointed by each fat_arch struct
         void *tempBuf = qalloc(ntohl(tempFatArch.size));
-        if(!get_bytes(address+ntohl(tempFatArch.offset), tempBuf, ntohl(tempFatArch.size)))
+        if(!get_bytes(tempBuf, ntohl(tempFatArch.size), address+ntohl(tempFatArch.offset)))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;

--- a/validate.cpp
+++ b/validate.cpp
@@ -45,7 +45,7 @@ validate_macho(ea_t address)
 #if DEBUG
     msg("[DEBUG] Executing validate macho at address %x\n", address);
 #endif
-    uint32_t magic = get_long(address);
+    uint32_t magic = get_dword(address);
     
     // default is failure
     uint8_t retvalue = 1;

--- a/validate.cpp
+++ b/validate.cpp
@@ -54,7 +54,7 @@ validate_macho(ea_t address)
         // validate cpu type
         struct mach_header header;
         // retrieve mach_header contents
-        if(!get_many_bytes(address, &header, sizeof(struct mach_header)))
+        if(!get_bytes(address, &header, sizeof(struct mach_header)))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -100,7 +100,7 @@ validate_macho(ea_t address)
         // validate cpu type
         struct mach_header_64 header64;
         // retrieve mach_header contents
-        if(!get_many_bytes(address, &header64, sizeof(struct mach_header_64)))
+        if(!get_bytes(address, &header64, sizeof(struct mach_header_64)))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -176,7 +176,7 @@ validate_fat(struct fat_header fatHeader, ea_t position)
             for (uint32_t i = 0; i < nfat_arch; i++)
             {
                 struct fat_arch fatArch;
-                get_many_bytes(address, &fatArch, sizeof(struct fat_arch));
+                get_bytes(address, &fatArch, sizeof(struct fat_arch));
                 uint32_t cputype = ntohl(fatArch.cputype);
                 uint32_t cpusubtype = ntohl(fatArch.cpusubtype);
                 // validate cpu type & subtype, hopefully false positives rate is extremely low

--- a/validate.cpp
+++ b/validate.cpp
@@ -54,7 +54,7 @@ validate_macho(ea_t address)
         // validate cpu type
         struct mach_header header;
         // retrieve mach_header contents
-        if(!get_bytes(address, &header, sizeof(struct mach_header)))
+        if(!get_bytes(&header, sizeof(struct mach_header), address))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -100,7 +100,7 @@ validate_macho(ea_t address)
         // validate cpu type
         struct mach_header_64 header64;
         // retrieve mach_header contents
-        if(!get_bytes(address, &header64, sizeof(struct mach_header_64)))
+        if(!get_bytes(&header64, sizeof(struct mach_header_64), address))
         {
             msg("[ERROR] Read bytes failed!\n");
             return 1;
@@ -176,7 +176,7 @@ validate_fat(struct fat_header fatHeader, ea_t position)
             for (uint32_t i = 0; i < nfat_arch; i++)
             {
                 struct fat_arch fatArch;
-                get_bytes(address, &fatArch, sizeof(struct fat_arch));
+                get_bytes(&fatArch, sizeof(struct fat_arch), address);
                 uint32_t cputype = ntohl(fatArch.cputype);
                 uint32_t cpusubtype = ntohl(fatArch.cpusubtype);
                 // validate cpu type & subtype, hopefully false positives rate is extremely low


### PR DESCRIPTION
Hello

I updated ExtractMachO for IDA 7.

Please note that, as per Hex-Rays suggestion, we now use SDK build system.
In order to compile the plugin, it now has to be located in `idasdk70/plugins/ExtractMachO`.

Cheers.

Arnaud